### PR TITLE
fix: allow numbers and booleans as validation message "$value" tokens

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,17 @@
 ## PR Checklist
+
 Please check if your PR fulfills the following requirements:
 
 - [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-
 ## PR Type
+
 What kind of change does this PR introduce?
 
 <!-- Please check the one that applies to this PR using "x". -->
+
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
@@ -19,19 +21,18 @@ What kind of change does this PR introduce?
 - [ ] Other... Please describe:
 
 ## What is the current behavior?
+
 <!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 
 Issue Number: N/A
 
-
 ## What is the new behavior?
 
-
 ## Does this PR introduce a breaking change?
+
 - [ ] Yes
 - [ ] No
 
 <!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
-
 
 ## Other information

--- a/src/validation/ValidationUtils.ts
+++ b/src/validation/ValidationUtils.ts
@@ -36,7 +36,7 @@ export class ValidationUtils {
       messageString &&
       validationArguments.value !== undefined &&
       validationArguments.value !== null &&
-      typeof validationArguments.value === 'string'
+      ['string', 'boolean', 'number'].includes(typeof validationArguments.value)
     )
       messageString = messageString.replace(/\$value/g, validationArguments.value);
     if (messageString) messageString = messageString.replace(/\$property/g, validationArguments.property);

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1,7 +1,9 @@
 import {
   Contains,
+  Equals,
   IsDefined,
   Matches,
+  Max,
   MinLength,
   Validate,
   ValidateNested,
@@ -56,7 +58,7 @@ describe('message', () => {
     });
   });
 
-  it('$value token should be replaced in a custom message', () => {
+  it('$value token should be replaced in a custom message with a string', () => {
     class MyClass {
       @MinLength(2, {
         message: args => {
@@ -73,6 +75,38 @@ describe('message', () => {
     return validator.validate(model).then(errors => {
       expect(errors.length).toEqual(1);
       expect(errors[0].constraints).toEqual({ minLength: ' is too short, minimum length is 2 characters name' });
+    });
+  });
+
+  it('$value token should be replaced in a custom message with a number', () => {
+    class MyClass {
+      @Max(100, { message: 'Maximum value is $constraint1, but actual is $value' })
+      val: number = 50;
+    }
+
+    const model = new MyClass();
+    model.val = 101;
+    return validator.validate(model).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].constraints).toEqual({
+        max: 'Maximum value is 100, but actual is 101',
+      });
+    });
+  });
+
+  it('$value token should be replaced in a custom message with a boolean', () => {
+    class MyClass {
+      @Equals(true, { message: 'Value must be $constraint1, but actual is $value' })
+      val: boolean = false;
+    }
+
+    const model = new MyClass();
+    model.val = false;
+    return validator.validate(model).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].constraints).toEqual({
+        equals: 'Value must be true, but actual is false',
+      });
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `$value` token placed in the validation message is parsed as expected only when the provided value is of type string, which results in commonly used validators with non-string values such as `@MinLength`, `@Min`, `@MaxLength`, `@Max` ect. to leave the $value token in the validation message without replacing it. This PR relaxes the runtime typecheck performed when constructing the validation message by allowing types boolean and number (alongside string) to act as $value token replacements.

Documented in issues: typestack/class-validator#921, typestack/class-validator#1046, also reported in the NestJS repo as nestjs/nest#6431

## What is the new behavior?

As documented in README examples - `$value` tokens will be replaced in the validation error message even if the underlying value is a string or a boolean.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Thanks for taking the time to create this fork. I have opened a PR with the same changes against the original repo, but given its rather stale maintenance status I thought that I might as well do it here.

I have also fixed formatting of the PR template file which was causing the CI pipeline to fail.